### PR TITLE
passthrough for unknown kwargs in backend.run

### DIFF
--- a/runningman/backend.py
+++ b/runningman/backend.py
@@ -74,7 +74,7 @@ class RunningManBackend:
         return ESTIMATOR(mode=self._mode if self._mode else self.backend)
 
     def run(
-        self, circuits, shots=None, job_tags=None, rep_delay=None, init_qubits=True
+        self, circuits, shots=None, job_tags=None, rep_delay=None, init_qubits=True, **kwargs
     ):
         """Standard Qiskit run mode
 


### PR DESCRIPTION
Allow for unkown kwargs to just go through `backend.run()`