### PR TITLE
Add ability to get jobs from provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 runningman/version.py
+.DS_Store

--- a/runningman/backend.py
+++ b/runningman/backend.py
@@ -127,4 +127,4 @@ class RunningManBackend(IBMBackend):
         if not isinstance(circuits, Iterable):
             circuits = [circuits]
         job = sampler.run(circuits, shots=shots)
-        return RunningManJob(job, executor="sampler")
+        return RunningManJob(job)

--- a/runningman/backend.py
+++ b/runningman/backend.py
@@ -119,10 +119,6 @@ class RunningManBackend(IBMBackend):
         sampler.options.execution.init_qubits = init_qubits
         if rep_delay:
             sampler.options.execution.rep_delay = rep_delay
-        if job_tags:
-            job_tags.append("\u2003")
-        else:
-            job_tags = ["\u2003"]
         sampler.options.environment.job_tags = job_tags
         if not isinstance(circuits, Iterable):
             circuits = [circuits]

--- a/runningman/job.py
+++ b/runningman/job.py
@@ -12,6 +12,7 @@
 """
 import types
 from qiskit.result import Counts
+from qiskit.primitives.containers import SamplerPubResult
 
 
 class RunningManJob:
@@ -20,11 +21,8 @@ class RunningManJob:
     Unlike the Runtime, the results are cached
     """
 
-    def __init__(self, job, executor):
+    def __init__(self, job):
         self.job = job
-        if executor not in ["sampler", "estimator"]:
-            raise ValueError("executor must be one of 'sampler' or 'estimator'")
-        self.executor = executor
         self._result = None  # cache the job result
 
     def __getattr__(self, attr):
@@ -44,10 +42,11 @@ class RunningManJob:
             return self._result
         else:
             res = self.job.result()
-            setattr(res, "get_counts", _get_counts)
-            res.get_counts = types.MethodType(_get_counts, res)
-            setattr(res, "get_memory", _get_memory)
-            res.get_memory = types.MethodType(_get_memory, res)
+            if isinstance(res[0], SamplerPubResult):
+                setattr(res, "get_counts", _get_counts)
+                res.get_counts = types.MethodType(_get_counts, res)
+                setattr(res, "get_memory", _get_memory)
+                res.get_memory = types.MethodType(_get_memory, res)
             self._result = res
             return res
 

--- a/runningman/job.py
+++ b/runningman/job.py
@@ -24,11 +24,19 @@ class RunningManJob:
     def __init__(self, job):
         self.job = job
         self._result = None  # cache the job result
+        self.executor = None
 
     def __getattr__(self, attr):
         if attr in self.__dict__:
             return self.__dict__[attr]
         return getattr(self.job, attr)
+    
+    def __repr__(self):
+        job_id = self.job.job_id()
+        backend_name = self.job.backend().name
+        executor = self.executor if self.executor else 'NA'
+        out_str = f"RunningManJob<job_id='{job_id}', backend_name='{backend_name}', executor='{executor}'>"
+        return out_str
 
     def result(self):
         """Get the result from a job
@@ -47,6 +55,9 @@ class RunningManJob:
                 res.get_counts = types.MethodType(_get_counts, res)
                 setattr(res, "get_memory", _get_memory)
                 res.get_memory = types.MethodType(_get_memory, res)
+                self.executor = 'sampler'
+            else:
+                self.executor = 'estimator'
             self._result = res
             return res
 

--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -46,3 +46,14 @@ class RunningManProvider:
         """
         job = self.service.job(job_id)
         return RunningManJob(job)
+    
+    def jobs(self, *args, **kwargs):
+        """Retrieve runtime jobs with filtering.
+
+        Input arguments are the same as `QiskitRuntimeService.jobs()`
+      
+        Returns:
+            list: A list of RunnningManJobs 
+        """
+        jobs = self.service.jobs(*args, **kwargs)
+        return [RunningManJob(job) for job in jobs]

--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -13,6 +13,7 @@
 from qiskit_ibm_runtime import QiskitRuntimeService
 
 from runningman.backend import RunningManBackend
+from runningman.job import RunningManJob  
 
 
 class RunningManProvider:
@@ -21,6 +22,11 @@ class RunningManProvider:
     def __init__(self, *args, **kwargs):
         self.service = QiskitRuntimeService(*args, **kwargs)
 
+    def __getattr__(self, attr):
+        if attr in self.__dict__:
+            return self.__dict__[attr]
+        return getattr(self.service, attr)
+
     def backend(self, name):
         backend = self.service.backend(name)
         return RunningManBackend(backend)
@@ -28,3 +34,15 @@ class RunningManProvider:
     def backends(self):
         backend_list = self.service.backends()
         return [RunningManBackend(back) for back in backend_list]
+
+    def job(self, job_id):
+        """Return a specific job given a job_id
+
+        Parameters:
+            job_id (str): A job ID string
+        
+        Returns:
+            RunningManJob: The requested job instance in RunningMan format
+        """
+        job = self.service.job(job_id)
+        return RunningManJob(job)


### PR DESCRIPTION
Allows for round tripping of jobs to have `get_counts` and `get_memory` attached to sampler jobs