### PR TITLE
Add some Tests

### DIFF
--- a/runningman/test/__init__.py
+++ b/runningman/test/__init__.py
@@ -1,0 +1,16 @@
+# This code is part of runningman.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+import os
+import runningman as rm
+
+
+PROVIDER = rm.RunningManProvider()
+# Get backend from env var or default to open Brisbane
+BACKEND = PROVIDER.backend(os.environ.get('RM_BACKEND', 'ibm_brisbane'))

--- a/runningman/test/test_basic.py
+++ b/runningman/test/test_basic.py
@@ -8,6 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 from qiskit import *
+import runningman.test
 from runningman.test import BACKEND
 
 
@@ -23,6 +24,8 @@ def test_run_basics():
 
     trans_qc = transpile(qc, BACKEND)
     job = BACKEND.run(trans_qc, shots=1234)
+    runningman.test.TEMP_JOB_ID = job.job_id()
+    assert job.backend().name == runningman.test.BACKEND.name
     counts = job.result().get_counts()
     assert sum(counts.values()) == 1234
     assert len(next(iter(counts))) == 5

--- a/runningman/test/test_basic.py
+++ b/runningman/test/test_basic.py
@@ -23,11 +23,11 @@ def test_run_basics():
     qc.measure_all()
 
     trans_qc = transpile(qc, BACKEND)
-    job = BACKEND.run(trans_qc, shots=1234)
+    job = BACKEND.run(trans_qc, shots=135)
     runningman.test.TEMP_JOB_ID = job.job_id()
     assert job.backend().name == runningman.test.BACKEND.name
     counts = job.result().get_counts()
-    assert sum(counts.values()) == 1234
+    assert sum(counts.values()) == 135
     assert len(next(iter(counts))) == 5
 
 
@@ -46,9 +46,9 @@ def test_run_two_cregs1():
     qc.measure([2,3,4], cr2)
 
     trans_qc = transpile(qc, BACKEND)
-    job = BACKEND.run(trans_qc, shots=1234)
+    job = BACKEND.run(trans_qc, shots=135)
     counts = job.result().get_counts()
-    assert sum(counts.values()) == 1234
+    assert sum(counts.values()) == 135
     key = next(iter(counts))
     key_chunks = key.split(' ')
     assert len(key_chunks[0]) == 3
@@ -70,9 +70,9 @@ def test_run_two_cregs2():
     qc.measure([2,3,4], cr2)
 
     trans_qc = transpile(qc, BACKEND)
-    job = BACKEND.run(trans_qc, shots=1234)
+    job = BACKEND.run(trans_qc, shots=135)
     counts = job.result().get_counts()
-    assert sum(counts.values()) == 1234
+    assert sum(counts.values()) == 135
     key = next(iter(counts))
     key_chunks = key.split(' ')
     assert len(key_chunks[1]) == 3

--- a/runningman/test/test_job.py
+++ b/runningman/test/test_job.py
@@ -16,8 +16,9 @@ def test_job_retrieval():
     """Test that a job has the correct properties"""
     provider = runningman.test.PROVIDER
     job = provider.job(runningman.test.TEMP_JOB_ID)
+
     assert job.backend().name == runningman.test.BACKEND.name
     assert isinstance(job, rm.job.RunningManJob)
     counts = job.result().get_counts()
-    assert sum(counts.values()) == 1234
+    assert sum(counts.values()) == 135
     assert len(next(iter(counts))) == 5

--- a/runningman/test/test_job.py
+++ b/runningman/test/test_job.py
@@ -7,12 +7,17 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-import os
+from qiskit import *
 import runningman as rm
+import runningman.test
 
 
-PROVIDER = rm.RunningManProvider()
-# Get backend from env var or default to open Brisbane
-BACKEND = PROVIDER.backend(os.environ.get('RM_BACKEND', 'ibm_brisbane'))
-# holder for a job id used across tests
-TEMP_JOB_ID = None
+def test_job_retrieval():
+    """Test that a job has the correct properties"""
+    provider = runningman.test.PROVIDER
+    job = provider.job(runningman.test.TEMP_JOB_ID)
+    assert job.backend().name == runningman.test.BACKEND.name
+    assert isinstance(job, rm.job.RunningManJob)
+    counts = job.result().get_counts()
+    assert sum(counts.values()) == 1234
+    assert len(next(iter(counts))) == 5

--- a/runningman/test/test_memory.py
+++ b/runningman/test/test_memory.py
@@ -1,0 +1,52 @@
+# This code is part of runningman.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+from qiskit import *
+from runningman.test import BACKEND
+
+
+def test_run_memory1():
+    """Test getting memory from a job"""
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2,1)
+    qc.cx(1,0)
+    qc.cx(2,3)
+    qc.cx(3,4)
+    qc.measure_all()
+
+    trans_qc = transpile(qc, BACKEND)
+    job = BACKEND.run(trans_qc, shots=135)
+    
+    memory = job.result().get_memory()
+    assert len(memory) == 135
+    assert len(memory[0]) == 5
+
+
+def test_run_memory2():
+    """Test getting memory from a job with two cregs"""
+    qr = QuantumRegister(5)
+    cr1 = ClassicalRegister(2)
+    cr2 = ClassicalRegister(3)
+    qc = QuantumCircuit(qr, cr1, cr2)
+    qc.h(2)
+    qc.cx(2,1)
+    qc.cx(1,0)
+    qc.cx(2,3)
+    qc.cx(3,4)
+    qc.measure([0,1], cr1)
+    qc.measure([2,3,4], cr2)
+
+    trans_qc = transpile(qc, BACKEND)
+    job = BACKEND.run(trans_qc, shots=135)
+    memory = job.result().get_memory()
+    assert len(memory) == 135
+    key_chunks = memory[0].split(' ')
+    assert len(key_chunks[0]) == 3
+    assert len(key_chunks[1]) == 2

--- a/runningman/test/test_modes.py
+++ b/runningman/test/test_modes.py
@@ -1,0 +1,34 @@
+# This code is part of runningman.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+from qiskit import *
+from runningman.test import BACKEND, PROVIDER
+
+
+def test_run_modes():
+    """Test mode gets used by job"""
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2,1)
+    qc.cx(1,0)
+    qc.cx(2,3)
+    qc.cx(3,4)
+    qc.measure_all()
+
+    trans_qc = transpile(qc, BACKEND)
+    mode = BACKEND.set_mode('batch')
+    job = BACKEND.run(trans_qc, shots=135)
+    BACKEND.close_mode()
+    
+    assert job.session_id == mode.session_id
+    assert job.session_id == BACKEND.get_mode().session_id
+
+    provider = PROVIDER
+    job2 = provider.job(job.job_id())
+    assert job2.session_id == mode.session_id

--- a/runningman/test/test_modes.py
+++ b/runningman/test/test_modes.py
@@ -32,3 +32,4 @@ def test_run_modes():
     provider = PROVIDER
     job2 = provider.job(job.job_id())
     assert job2.session_id == mode.session_id
+    BACKEND.clear_mode()

--- a/runningman/test/test_run_basic.py
+++ b/runningman/test/test_run_basic.py
@@ -1,0 +1,76 @@
+# This code is part of runningman.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+from qiskit import *
+from runningman.test import BACKEND
+
+
+def test_run_basics():
+    """Test backend.run basics"""
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2,1)
+    qc.cx(1,0)
+    qc.cx(2,3)
+    qc.cx(3,4)
+    qc.measure_all()
+
+    trans_qc = transpile(qc, BACKEND)
+    job = BACKEND.run(trans_qc, shots=1234)
+    counts = job.result().get_counts()
+    assert sum(counts.values()) == 1234
+    assert len(next(iter(counts))) == 5
+
+
+def test_run_two_cregs1():
+    """Test backend.run with two cregs"""
+    qr = QuantumRegister(5)
+    cr1 = ClassicalRegister(2)
+    cr2 = ClassicalRegister(3)
+    qc = QuantumCircuit(qr, cr1, cr2)
+    qc.h(2)
+    qc.cx(2,1)
+    qc.cx(1,0)
+    qc.cx(2,3)
+    qc.cx(3,4)
+    qc.measure([0,1], cr1)
+    qc.measure([2,3,4], cr2)
+
+    trans_qc = transpile(qc, BACKEND)
+    job = BACKEND.run(trans_qc, shots=1234)
+    counts = job.result().get_counts()
+    assert sum(counts.values()) == 1234
+    key = next(iter(counts))
+    key_chunks = key.split(' ')
+    assert len(key_chunks[0]) == 3
+    assert len(key_chunks[1]) == 2
+
+
+def test_run_two_cregs2():
+    """Test backend.run with two cregs"""
+    qr = QuantumRegister(5)
+    cr1 = ClassicalRegister(2)
+    cr2 = ClassicalRegister(3)
+    qc = QuantumCircuit(qr, cr2, cr1)
+    qc.h(2)
+    qc.cx(2,1)
+    qc.cx(1,0)
+    qc.cx(2,3)
+    qc.cx(3,4)
+    qc.measure([0,1], cr1)
+    qc.measure([2,3,4], cr2)
+
+    trans_qc = transpile(qc, BACKEND)
+    job = BACKEND.run(trans_qc, shots=1234)
+    counts = job.result().get_counts()
+    assert sum(counts.values()) == 1234
+    key = next(iter(counts))
+    key_chunks = key.split(' ')
+    assert len(key_chunks[1]) == 3
+    assert len(key_chunks[0]) == 2


### PR DESCRIPTION
Adds tests.  Since the `ibmq_qasm_simulator` is removed, these tests must call real devices, and thus are not executed automatically.

The device is set with the env var `RM_BACKEND` and defaults to the open `ibm_brisbane` system if this var is not set.