### PR TITLE
Allow kwargs for geting backends

### DIFF
--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -15,6 +15,15 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from runningman.backend import RunningManBackend
 from runningman.job import RunningManJob
 
+def copy_doc(copy_func):
+    """Copies the doc string of the given function to another. 
+    """
+    def wrapped(func):
+        func.__doc__ = copy_func.__doc__
+        return func
+
+    return wrapped
+
 
 class RunningManProvider:
     """A provider that impliments the RunningMan interfaces"""
@@ -28,15 +37,14 @@ class RunningManProvider:
         return getattr(self.service, attr)
 
     def backend(self, name, *args, **kwargs):
-        """An instance of the specified backend
-
-        Returns:
-            RunningManBackend
+        """Get an instance of a backend
         """
         backend = self.service.backend(name, *args, **kwargs)
         return RunningManBackend(backend)
 
     def backends(self, *args, **kwargs):
+        """List available backends, with optional filtering
+        """
         backend_list = self.service.backends(*args, **kwargs)
         return [RunningManBackend(back) for back in backend_list]
 

--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -27,12 +27,17 @@ class RunningManProvider:
             return self.__dict__[attr]
         return getattr(self.service, attr)
 
-    def backend(self, name):
-        backend = self.service.backend(name)
+    def backend(self, name, *args, **kwargs):
+        """An instance of the specified backend
+
+        Returns:
+            RunningManBackend
+        """
+        backend = self.service.backend(name, *args, **kwargs)
         return RunningManBackend(backend)
 
-    def backends(self):
-        backend_list = self.service.backends()
+    def backends(self, *args, **kwargs):
+        backend_list = self.service.backends(*args, **kwargs)
         return [RunningManBackend(back) for back in backend_list]
 
     def job(self, job_id):

--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -15,15 +15,6 @@ from qiskit_ibm_runtime import QiskitRuntimeService
 from runningman.backend import RunningManBackend
 from runningman.job import RunningManJob
 
-def copy_doc(copy_func):
-    """Copies the doc string of the given function to another. 
-    """
-    def wrapped(func):
-        func.__doc__ = copy_func.__doc__
-        return func
-
-    return wrapped
-
 
 class RunningManProvider:
     """A provider that impliments the RunningMan interfaces"""

--- a/runningman/test/test_provider.py
+++ b/runningman/test/test_provider.py
@@ -1,0 +1,26 @@
+# This code is part of runningman.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+import runningman as rm
+
+
+def test_backends_kwargs():
+    """Test that backends query with kwarg works"""
+    provider = runningman.test.PROVIDER
+    backends = provider.backends(min_num_qubits=127)
+    for backend in backends:
+        assert backend.num_qubits >= 127
+
+
+def test_backends_kwargs2():
+    """Test that backends query with impossible kwarg works"""
+    provider = runningman.test.PROVIDER
+    backends = provider.backends(min_num_qubits=int(1e12))
+    assert not any(backends)
+

--- a/runningman/test/test_provider.py
+++ b/runningman/test/test_provider.py
@@ -7,7 +7,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-import runningman as rm
+import runningman
 
 
 def test_backends_kwargs():


### PR DESCRIPTION
Allow for passing kwargs to `provider.backend` and `provider.backends`