### PR TITLE
Update close

### DIFF
--- a/runningman/backend.py
+++ b/runningman/backend.py
@@ -93,7 +93,7 @@ class RunningManBackend(IBMBackend):
 
     def clear_mode(self):
         """Clear the current mode from the backend
-        
+
         Will close any mode that currently exists.
 
         """

--- a/runningman/backend.py
+++ b/runningman/backend.py
@@ -56,6 +56,8 @@ class RunningManBackend(IBMBackend):
             raise Exception(
                 "backend mode is already set.  use overwrite=True or clear the mode"
             )
+        if self._mode:
+            self.close_mode()
         if mode == "batch":
             mode = Batch(backend=self.backend)
             self._mode = mode
@@ -90,7 +92,13 @@ class RunningManBackend(IBMBackend):
             raise Exception("No mode to close")
 
     def clear_mode(self):
-        """Clear the current mode from the backend"""
+        """Clear the current mode from the backend
+        
+        Will close any mode that currently exists.
+
+        """
+        if self._mode:
+            self._mode.close()
         self._mode = None
 
     def get_sampler(self):

--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -28,14 +28,12 @@ class RunningManProvider:
         return getattr(self.service, attr)
 
     def backend(self, name, *args, **kwargs):
-        """Get an instance of a backend
-        """
+        """Get an instance of a backend"""
         backend = self.service.backend(name, *args, **kwargs)
         return RunningManBackend(backend)
 
     def backends(self, *args, **kwargs):
-        """List available backends, with optional filtering
-        """
+        """List available backends, with optional filtering"""
         backend_list = self.service.backends(*args, **kwargs)
         return [RunningManBackend(back) for back in backend_list]
 

--- a/runningman/test/test_provider.py
+++ b/runningman/test/test_provider.py
@@ -23,4 +23,3 @@ def test_backends_kwargs2():
     provider = runningman.test.PROVIDER
     backends = provider.backends(min_num_qubits=int(1e12))
     assert not any(backends)
-


### PR DESCRIPTION
`backend.close_mode` and `backend.set_mode( *, overwrite=True)` will now close any mode that is attached to the backend

closes #12 