### PR TITLE
Fix session_infobroken by runtime update

### DIFF
--- a/runningman/__init__.py
+++ b/runningman/__init__.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan
-"""
+"""RunningMan"""
 
 try:
     from .version import version as __version__

--- a/runningman/backend.py
+++ b/runningman/backend.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan backend
-"""
+"""RunningMan backend"""
 import copy
 from collections.abc import Iterable
 from qiskit_ibm_runtime import Batch, Session, SamplerV2, EstimatorV2, IBMBackend

--- a/runningman/job.py
+++ b/runningman/job.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan job
-"""
+"""RunningMan job"""
 import types
 from qiskit.result import Counts
 from qiskit.primitives.containers import SamplerPubResult

--- a/runningman/mode.py
+++ b/runningman/mode.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan mode
-"""
+"""RunningMan mode"""
 from qiskit_ibm_runtime import Session
 
 

--- a/runningman/options.py
+++ b/runningman/options.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan options
-"""
+"""RunningMan options"""
 from qiskit_ibm_runtime import SamplerOptions
 
 
@@ -26,7 +25,7 @@ class ExecutionOptions(dict):
         out += "=" * 50 + "\n"
         for key, val in self.items():
             indent = 0
-            out += "\u23F5" + key + "\n"
+            out += "\u23f5" + key + "\n"
             indent = 2
             for item, entry in val.items():
                 out += (
@@ -52,7 +51,7 @@ class SuppressionOptions(dict):
         out += "=" * 50 + "\n"
         for key, val in self.items():
             indent = 0
-            out += "\u23F5" + key + "\n"
+            out += "\u23f5" + key + "\n"
             indent = 2
             for item, entry in val.items():
                 out += (

--- a/runningman/provider.py
+++ b/runningman/provider.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan provider
-"""
+"""RunningMan provider"""
 from qiskit_ibm_runtime import QiskitRuntimeService, Batch, Session
 
 from runningman.backend import RunningManBackend
@@ -72,7 +71,8 @@ class RunningManProvider:
         Returns:
             RunningManMode: The mode instance
         """
-        response = self._api_client.session_details(mode_id)
+        crn = self.service.active_instance()
+        response = self.service._api_clients[crn].session_details(mode_id)
         mode = response.get("mode")
         if mode == "batch":
             temp_mode = Batch.from_id(mode_id, self)

--- a/runningman/utils.py
+++ b/runningman/utils.py
@@ -8,8 +8,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""RunningMan utilities
-"""
+"""RunningMan utilities"""
 from qiskit_ibm_runtime import IBMBackend
 
 from runningman.backend import RunningManBackend


### PR DESCRIPTION
The Qiskit Runtime broken the way `session_info` works when moving to IBM Cloud. This fixes that